### PR TITLE
feat: enable remove button for every generated card in any cards section

### DIFF
--- a/src/components/views/read/PlayerView.tsx
+++ b/src/components/views/read/PlayerView.tsx
@@ -24,6 +24,7 @@ const PlayerView: FC = () => {
   const nextStep = (): void => setActiveStep(activeStep + 1);
   const prevStep = (): void => setActiveStep(activeStep - 1);
   const homeStep = (): void => setActiveStep(0);
+  const templateStep = (): void => setActiveStep(8);
   const steps = [
     'Home',
     'Personal Info',
@@ -73,12 +74,21 @@ const PlayerView: FC = () => {
       [subkey]: newSubkeyValues,
     }));
   };
-
+  const handleUploadCvValues = (data: CVInfoObj): void => {
+    setCvValues(data);
+  };
   return (
     <Box data-cy={PLAYER_VIEW_CY}>
       <FormLayout activeStep={activeStep} steps={steps}>
         {/* We can also instead use Switch-Cases for the rendering process */}
-        {activeStep === 0 && <Home nextPage={nextPage} nextStep={nextStep} />}
+        {activeStep === 0 && (
+          <Home
+            nextPage={nextPage}
+            nextStep={nextStep}
+            templateStep={templateStep}
+            onCvValuesUpload={(cvData) => handleUploadCvValues(cvData)}
+          />
+        )}
         {activeStep === 1 && (
           <PersonalInfo
             nextPage={nextPage}

--- a/src/components/views/read/PlayerView.tsx
+++ b/src/components/views/read/PlayerView.tsx
@@ -176,6 +176,7 @@ const PlayerView: FC = () => {
             nextPage={nextPage}
             prevPage={prevPage}
             nextStep={nextStep}
+            homeStep={homeStep}
             prevStep={prevStep}
             cvValues={cvValues}
             templateData={cvValues.templateInfo}

--- a/src/components/views/read/cvForm/Education.tsx
+++ b/src/components/views/read/cvForm/Education.tsx
@@ -309,7 +309,6 @@ const Education: FC<Props> = ({
                 )}
                 <Button
                   size="small"
-                  disabled={educationCards.length === 1}
                   startIcon={<DeleteIcon />}
                   onClick={() => handleRemove(card.id)}
                 >

--- a/src/components/views/read/cvForm/Home.tsx
+++ b/src/components/views/read/cvForm/Home.tsx
@@ -1,18 +1,50 @@
-import { FC } from 'react';
+import { ChangeEvent, FC, RefObject, useRef } from 'react';
 
 import { Add } from '@mui/icons-material';
+import UploadFileIcon from '@mui/icons-material/UploadFile';
 import { Box, Button, Stack, Typography } from '@mui/material';
+
+import { CVInfoObj } from './types';
 
 interface Props {
   nextPage: () => void;
   nextStep: () => void;
+  templateStep: () => void;
+  onCvValuesUpload: (cvData: CVInfoObj) => void;
 }
-const Home: FC<Props> = ({ nextPage, nextStep }) => {
+const Home: FC<Props> = ({
+  nextPage,
+  nextStep,
+  templateStep,
+  onCvValuesUpload,
+}) => {
+  const inputRef: RefObject<HTMLInputElement> = useRef(null);
+  const onChange = (e: ChangeEvent<HTMLInputElement>): void => {
+    const { files } = e.target;
+    const file = files?.[0];
+
+    if (file) {
+      const reader = new FileReader();
+      reader.onload = () => {
+        const fileContent = reader.result as string;
+        const parsedData = JSON.parse(fileContent) as CVInfoObj;
+        onCvValuesUpload(parsedData);
+
+        templateStep();
+      };
+      reader.readAsText(file);
+    }
+  };
+  const handleClick = (): void => {
+    if (inputRef.current) {
+      inputRef.current.value = '';
+      inputRef.current.click();
+    }
+  };
   const handleNext = (): void => {
     nextPage();
     nextStep(); // Update the activeStep state
   };
-
   return (
     <Box m={2} p={1} border="1px solid gray" borderRadius={2}>
       <Stack spacing={2}>
@@ -29,6 +61,21 @@ const Home: FC<Props> = ({ nextPage, nextStep }) => {
             onClick={handleNext}
           >
             Create
+          </Button>
+          <input
+            type="file"
+            accept=".json"
+            style={{ display: 'none' }}
+            ref={inputRef}
+            onChange={onChange}
+          />
+          <Button
+            startIcon={<UploadFileIcon />}
+            variant="contained"
+            color="primary"
+            onClick={handleClick}
+          >
+            Upload Data
           </Button>
         </Stack>
       </Stack>

--- a/src/components/views/read/cvForm/PersonalInfo.tsx
+++ b/src/components/views/read/cvForm/PersonalInfo.tsx
@@ -1,13 +1,30 @@
 import dayjs from 'dayjs';
 
-import { FC, Fragment, RefObject, useEffect, useRef, useState } from 'react';
+import {
+  ChangeEvent,
+  FC,
+  Fragment,
+  RefObject,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 import PhoneInput from 'react-phone-input-2';
 import 'react-phone-input-2/lib/style.css';
 
+import ClearIcon from '@mui/icons-material/Clear';
 import NavigateBeforeIcon from '@mui/icons-material/NavigateBefore';
 import NavigateNextIcon from '@mui/icons-material/NavigateNext';
 import UploadFileIcon from '@mui/icons-material/UploadFile';
-import { Box, Button, MenuItem, TextField, Typography } from '@mui/material';
+import VisibilityIcon from '@mui/icons-material/Visibility';
+import {
+  Box,
+  Button,
+  IconButton,
+  MenuItem,
+  TextField,
+  Typography,
+} from '@mui/material';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { DatePicker } from '@mui/x-date-pickers/DatePicker';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
@@ -43,7 +60,6 @@ const PersonalInfo: FC<Props> = ({
     { value: 'male', label: 'Male' },
     { value: 'noIndicate', label: 'Do not Indicate' },
   ];
-  const inputRef: RefObject<HTMLInputElement> = useRef(null);
   const mapping = [
     { key: 'firstName', label: 'First Name' },
     { key: 'lastName', label: 'Last Name' },
@@ -62,28 +78,81 @@ const PersonalInfo: FC<Props> = ({
   useEffect(() => {
     setPersonalInfoState(personalInfo);
   }, [personalInfo]);
-  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>): void => {
-    const file = e.target.files?.[0];
 
-    if (file) {
-      const reader = new FileReader();
-
-      reader.onloadend = () => {
-        setPersonalInfoState((prev) => ({
-          ...prev,
-          personalPic: reader.result as string,
-        }));
-      };
-
-      reader.readAsDataURL(file);
-    }
-  };
+  const inputRef: RefObject<HTMLInputElement> = useRef(null);
+  const [url, setUrl] = useState('');
+  const [uploadedFile, setUploadedFile] = useState<File | null>(null);
+  const [visibility, setVisibility] = useState(false);
 
   const handleClick = (): void => {
     if (inputRef.current) {
+      inputRef.current.value = '';
       inputRef.current.click();
     }
   };
+  const onChange = (e: ChangeEvent<HTMLInputElement>): void => {
+    const { files } = e.target;
+    const file = files?.[0];
+
+    if (file) {
+      const reader = new FileReader();
+      reader.onload = () => {
+        const dataUrl = reader.result;
+        setUrl(dataUrl as string);
+        setUploadedFile(file);
+        setPersonalInfoState((prev) => ({
+          ...prev,
+          personalPic: dataUrl as string,
+        }));
+      };
+      reader.readAsDataURL(file);
+    } else {
+      setUrl('');
+      setUploadedFile(null);
+      setPersonalInfoState((prev) => ({
+        ...prev,
+        personalPic: '',
+      }));
+    }
+  };
+
+  const handleFileRemove = (): void => {
+    setUrl('');
+    setUploadedFile(null);
+    setPersonalInfoState((prev) => ({
+      ...prev,
+      personalPic: '',
+    }));
+    if (inputRef.current) {
+      inputRef.current.value = '';
+    }
+  };
+  const handleVisibility = (): void => {
+    setVisibility(!visibility);
+  };
+
+  // const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>): void => {
+  //   const file = e.target.files?.[0];
+
+  //   if (file) {
+  //     const reader = new FileReader();
+
+  //     reader.onloadend = () => {
+  //       setPersonalInfoState((prev) => ({
+  //         ...prev,
+  //         personalPic: reader.result as string,
+  //       }));
+  //     };
+
+  //     reader.readAsDataURL(file);
+  //   }
+  // };
+
+  // const handleClick = (): void => {
+  //   if (inputRef.current) {
+  //     inputRef.current.click();
+  //   }
+  // };
 
   const handleNext = (): void => {
     onCvValuesChange(personalInfoState);
@@ -237,16 +306,6 @@ const PersonalInfo: FC<Props> = ({
             )}
             {m.key === 'personalPic' && (
               <>
-                <input
-                  type="file"
-                  accept="image/*"
-                  style={{ display: 'none' }}
-                  ref={inputRef}
-                  onChange={handleFileChange}
-                />
-                {personalInfoState.personalPic && (
-                  <img src={personalInfoState.personalPic} alt="Preview" />
-                )}
                 <Button
                   variant="contained"
                   color="primary"
@@ -255,6 +314,25 @@ const PersonalInfo: FC<Props> = ({
                 >
                   Upload Image
                 </Button>
+                <input
+                  type="file"
+                  accept="image/*"
+                  style={{ display: 'none' }}
+                  ref={inputRef}
+                  onChange={onChange}
+                />
+                {uploadedFile && (
+                  <Box display="flex" alignItems="center">
+                    <Typography>{uploadedFile.name}</Typography>
+                    <IconButton onClick={handleFileRemove} color="primary">
+                      <ClearIcon />
+                    </IconButton>
+                    <IconButton onClick={handleVisibility} color="primary">
+                      <VisibilityIcon />
+                    </IconButton>
+                  </Box>
+                )}
+                {visibility && url && <img src={url} alt="Preview" />}
               </>
             )}
           </Fragment>

--- a/src/components/views/read/cvForm/PersonalInfo.tsx
+++ b/src/components/views/read/cvForm/PersonalInfo.tsx
@@ -131,29 +131,6 @@ const PersonalInfo: FC<Props> = ({
     setVisibility(!visibility);
   };
 
-  // const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>): void => {
-  //   const file = e.target.files?.[0];
-
-  //   if (file) {
-  //     const reader = new FileReader();
-
-  //     reader.onloadend = () => {
-  //       setPersonalInfoState((prev) => ({
-  //         ...prev,
-  //         personalPic: reader.result as string,
-  //       }));
-  //     };
-
-  //     reader.readAsDataURL(file);
-  //   }
-  // };
-
-  // const handleClick = (): void => {
-  //   if (inputRef.current) {
-  //     inputRef.current.click();
-  //   }
-  // };
-
   const handleNext = (): void => {
     onCvValuesChange(personalInfoState);
     nextPage();

--- a/src/components/views/read/cvForm/Portfolio.tsx
+++ b/src/components/views/read/cvForm/Portfolio.tsx
@@ -215,13 +215,7 @@ const Portfolio: FC<Props> = ({
                                 ...prevShowFields,
                                 [card.id]: true,
                               }));
-                              // setIsPresent(e.target.checked);
-                              handleChange(
-                                card.id,
-                                'endDate',
-                                'OnGoing',
-                                // dayjs().format('YYYY-MM-DD'),
-                              );
+                              handleChange(card.id, 'endDate', 'OnGoing');
                             }}
                           />
                         </Box>
@@ -261,7 +255,6 @@ const Portfolio: FC<Props> = ({
                 )}
                 <Button
                   size="small"
-                  disabled={portfolioCards.length === 1}
                   startIcon={<DeleteIcon />}
                   onClick={() => handleRemove(card.id)}
                 >

--- a/src/components/views/read/cvForm/References.tsx
+++ b/src/components/views/read/cvForm/References.tsx
@@ -226,7 +226,6 @@ const References: FC<Props> = ({
                 )}
                 <Button
                   size="small"
-                  disabled={referencesCards.length === 1}
                   startIcon={<DeleteIcon />}
                   onClick={() => handleRemove(card.id)}
                 >

--- a/src/components/views/read/cvForm/Review.tsx
+++ b/src/components/views/read/cvForm/Review.tsx
@@ -33,8 +33,11 @@ const Review: FC<Props> = ({
   const renderedTemplate = <CvTemplate cvValues={cvValues} />;
 
   const handleDownload = async (): Promise<void> => {
-    const blob = await pdf(renderedTemplate).toBlob();
-    saveAs(blob, 'generated-cv.pdf');
+    const pdfBlob = await pdf(renderedTemplate).toBlob();
+    saveAs(pdfBlob, 'generated-cv.pdf');
+    const json = JSON.stringify(cvValues, null, 2); // Convert to JSON string with indentation
+    const jsonBlob = new Blob([json], { type: 'application/json' });
+    saveAs(jsonBlob, 'generated-cv.json');
   };
 
   const handleNext = (): void => {

--- a/src/components/views/read/cvForm/Template.tsx
+++ b/src/components/views/read/cvForm/Template.tsx
@@ -2,6 +2,7 @@ import { ChangeEvent, FC, RefObject, useRef, useState } from 'react';
 
 import ClearIcon from '@mui/icons-material/Clear';
 import DoneIcon from '@mui/icons-material/Done';
+import HomeIcon from '@mui/icons-material/Home';
 import NavigateBeforeIcon from '@mui/icons-material/NavigateBefore';
 import UploadFileIcon from '@mui/icons-material/UploadFile';
 import VisibilityIcon from '@mui/icons-material/Visibility';
@@ -25,6 +26,7 @@ interface Props {
   prevPage: () => void;
   nextStep: () => void;
   prevStep: () => void;
+  homeStep: () => void;
   cvValues: CVInfoObj;
   templateData: TemplateObj;
   onCvValuesChange: (data: TemplateObj) => void;
@@ -34,6 +36,7 @@ const Template: FC<Props> = ({
   prevPage,
   nextStep,
   prevStep,
+  homeStep,
   cvValues,
   templateData,
   onCvValuesChange,
@@ -136,6 +139,14 @@ const Template: FC<Props> = ({
         ref={inputRef}
         onChange={onChange}
       />
+      <Button
+        variant="contained"
+        color="primary"
+        startIcon={<HomeIcon />}
+        onClick={() => homeStep()}
+      >
+        Main
+      </Button>
       <Button
         variant="contained"
         color="primary"

--- a/src/components/views/read/cvForm/WorkExperience.tsx
+++ b/src/components/views/read/cvForm/WorkExperience.tsx
@@ -302,7 +302,6 @@ const WorkExperience: FC<Props> = ({
                 )}
                 <Button
                   size="small"
-                  disabled={workCards.length === 1}
                   startIcon={<DeleteIcon />}
                   onClick={() => handleRemove(card.id)}
                 >


### PR DESCRIPTION
In this PR:
.. closes #30 
.. closes #32  
.. closes #33 
.. closes #15 
.. We are going to enable the removing of cards, even if they are just one card, this existing limitation presence is becuase of the old approach of the cards structure and the way we generate them, starting by default of one card generated, but from now, the defualt is none "no cards generated", and the user will generate any amount of cards he\she would like to.
<img width="1920" alt="Screenshot 2023-06-27 at 11 19 30" src="https://github.com/graasp/graasp-app-cv-tools/assets/112824403/1df6bb91-03d6-4e64-9c55-613f655ed23b">
<img width="1920" alt="Screenshot 2023-06-27 at 11 26 20" src="https://github.com/graasp/graasp-app-cv-tools/assets/112824403/4a2ada8e-71c9-44e4-8424-a5d26531686b">
<img width="681" alt="Screenshot 2023-06-27 at 11 54 42" src="https://github.com/graasp/graasp-app-cv-tools/assets/112824403/aacfafb7-f236-4779-a8bd-cad0ea1e159d">
<img width="856" alt="Screenshot 2023-06-27 at 11 54 52" src="https://github.com/graasp/graasp-app-cv-tools/assets/112824403/8effc20a-412d-42ef-b16e-e29d682cb9e5">
